### PR TITLE
Selection reset on '/endpoints' after selecting endpoint methods or choosing different endpoints on dropdown

### DIFF
--- a/src/components/EndpointFormView.vue
+++ b/src/components/EndpointFormView.vue
@@ -1,0 +1,45 @@
+<template>
+  <div class="endpoint-form-view-container">
+    <h1>Endpoints</h1>
+
+    <doc name="endpoints1"></doc>
+
+    <h3>Create an Endpoint</h3>
+    <endpoint-form @save="endpointCreated"></endpoint-form>
+
+    <doc name="endpoints2"></doc>
+  </div>
+</template>
+
+<script>
+import EndpointForm from '../components/EndpointForm'
+
+export default {
+  components: {
+    EndpointForm
+  },
+  data () {
+    return {
+      editMethod: 'GET',
+      editPath: ''
+    }
+  },
+  computed: {
+    editUrl () {
+      return '/endpoints/' + encodeURIComponent(this.editMethod + ' ' + this.editPath)
+    }
+  },
+  methods: {
+    endpointCreated (path) {
+      this.$router.push({
+        name: 'endpoint',
+        params: { path }
+      })
+    }
+  }
+}
+
+</script>
+
+<style lang="css">
+</style>

--- a/src/components/EndpointMethodView.vue
+++ b/src/components/EndpointMethodView.vue
@@ -1,0 +1,127 @@
+<template>
+  <div class="method-view-container">
+    <p class="control has-addons is-pulled-right">
+      <router-link class="button" active-class="is-primary" :to="{ name: 'endpoint', params: {id: this.path}}" exact>
+        <span class="icon is-small">
+          <i class="fa fa-cog"></i>
+        </span>
+        <span>CONFIGURATION</span>
+      </router-link>
+      <router-link class="button" active-class="is-primary" :to="{ name: 'endpoint-reference', params: {id: this.path}}">
+        <span class="icon is-small">
+          <i class="fa fa-pencil-square-o"></i>
+        </span>
+        <span>DOCS</span>
+      </router-link>
+    </p>
+
+    <h1>{{ path }}</h1>
+    <div v-if="$route.name === 'endpoint'">
+
+      <h2>Access</h2>
+      <doc name="endpoint1"></doc>
+
+      <endpoint-access :path="path"></endpoint-access>
+
+      <doc name="endpoint2"></doc>
+
+      <h2>Parameters</h2>
+      <table class="table is-striped" v-if="configuration.params">
+        <thead>
+          <tr><th>Name</th><th>Validation</th><th></th></tr>
+        </thead>
+        <tbody>
+          <tr v-for="(param, name) in configuration.params">
+            <td>
+              <strong>{{name}}</strong>
+              <span v-if="param.required" class="tag is-dark">required</span>
+            </td>
+            <td v-if="param.regex">
+              <code>{{param.regex}}</code>
+            </td>
+            <td v-else>
+              <span class="tag is-danger">none</span>
+            </td>
+            <td v-if="isCoreEndpointParam(path, name) === 'core'">
+              <span class="tag is-light">core</span>
+            </td>
+            <td v-else>
+              <button @click="removeParam(name)" class="button is-danger is-small is-inverted"><span class="icon"><i class="fa fa-times"></i></span></button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <p v-else>There are no parameters defined for this endpoint.</p>
+
+      <h4 style="margin-top: 30px">Add a Parameter</h4>
+      <doc name="endpoint3"></doc>
+      <endpoint-param :path="path"></endpoint-param>
+
+      <doc name="endpoint4"></doc>
+      {{ path }}
+      {{ isCoreEndpoint(path + '/') }}
+      <div v-if="isCoreEndpoint(path) ===  'core'" class="notification is-warning" style="margin-top: 30px">
+        This core endpoint <strong>can't be removed</strong>.
+      </div>
+
+      <div v-else>
+        <h2 style="margin-top: 30px">Removal</h2>
+        <doc name="endpoint5"></doc>
+        <button @click="removeEndpoint" class="button is-danger is-outlined"><span class="icon"><i class="fa fa-times"></i></span><span>REMOVE ENDPOINT</span></button>
+      </div>
+    </div>
+    <div v-else>
+      <EndpointReference :endpoint="path"></EndpointReference>
+    </div>
+  </div>
+</template>
+
+<script>
+import EndpointAccess from '../components/EndpointAccess'
+import EndpointParam from '../components/EndpointParam'
+import EndpointsList from '../components/EndpointsList'
+import EndpointReference from '../components/EndpointReference'
+import { mapGetters } from 'vuex'
+
+export default {
+  components: {
+    EndpointAccess,
+    EndpointParam,
+    EndpointsList,
+    EndpointReference
+  },
+  data () {
+    return {
+      // param that is currently edited
+      editParam: null
+    }
+  },
+  computed: {
+    ...mapGetters(['endpoint', 'isCoreEndpoint', 'isCoreEndpointParam']),
+    path () {
+      return this.$route.params.path
+    },
+    configuration () {
+      return this.endpoint(this.path)
+    }
+  },
+  methods: {
+    removeEndpoint () {
+      this.$store.commit('REMOVE_ENDPOINT', {
+        path: this.path
+      })
+      this.$router.push('/endpoints')
+    },
+    removeParam (name) {
+      this.$store.commit('REMOVE_PARAM', {
+        path: this.path,
+        name
+      })
+      this.$forceUpdate()
+    }
+  }
+}
+</script>
+
+<style>
+</style>

--- a/src/components/RouteCard.vue
+++ b/src/components/RouteCard.vue
@@ -14,30 +14,28 @@
       <div class="card-content" v-show='showCard[i]'>
         <div class="content">
           <table class='table is-narrow'>
-            <thead>
-              <tr>
-                <th>Route</th>
-                <th>Methods</th>
-              </tr>
-            </thead>
             <tbody>
               <tr v-for='(child, childKey) in route.children'>
                 <td>
-                  <strong>{{ childKey }}</strong>
-                </td>
-                <td>
+                  <div>
+                    <strong v-if='childKey !== "/"'>{{ childKey }}</strong>
+                    <strong v-else>root <span class="path-root">(/{{ key }})</span></strong>
+                  </div>
                   <ul>
                     <li v-if='childKey !== "/"'>
                       <router-link active-class="is-active" :to="link(`${method} /${key}${childKey}`)" tag='span' class='tag' :class='classForMethod(method)' v-for='method in child' exact>
-                        {{ method }}
-                        <span class="mini tag is-dark" >{{ isCoreEndpoint(`${method} /${key}${childKey}`) }}</span>
+                        {{ method }}&nbsp;
+                        <i v-if="isCoreEndpoint(`${method} /${key}${childKey}`) === 'core'" class="fa fa-dot-circle-o" title="This is an Apiko core endpoint."></i>
+                        <i v-if="isCoreEndpoint(`${method} /${key}${childKey}`) === 'overridden'" class="fa fa-wrench" title="This is an overriden core endpoint."></i>
+                        <i v-if="isCoreEndpoint(`${method} /${key}${childKey}`) === 'custom'" class="fa fa-puzzle-piece" title="This is a custom endpoint."></i>
                       </router-link>
                     </li>
                     <li v-else>
-                      <router-link active-class="is-active" :to="link(`${method} /${key}`)" tag='span' class='tag' :class='classForMethod(method)' v-for='method in child' exact
->
-                        {{ method }}
-                        <span class="mini tag is-dark" >{{ isCoreEndpoint(`${method} /${key}`) }}</span>
+                      <router-link active-class="is-active" :to="link(`${method} /${key}`)" tag='span' class='tag' :class='classForMethod(method)' v-for='method in child' exact>
+                        {{ method }}&nbsp;
+                        <i v-if="isCoreEndpoint(`${method} /${key}${childKey}`) === 'core'" class="fa fa-dot-circle-o" title="This is an Apiko core endpoint."></i>
+                        <i v-if="isCoreEndpoint(`${method} /${key}${childKey}`) === 'overridden'" class="fa fa-wrench" title="This is an overriden core endpoint."></i>
+                        <i v-if="isCoreEndpoint(`${method} /${key}${childKey}`) === 'custom'" class="fa fa-puzzle-piece" title="This is a custom endpoint."></i>
                       </router-link>
                     </li>
                   </ul>
@@ -125,5 +123,9 @@ export default {
   border-radius: 2px;
   height: auto;
   padding: 0 5px;
+}
+
+.path-root {
+  color: #bbbbbb;
 }
 </style>

--- a/src/components/RouteCard.vue
+++ b/src/components/RouteCard.vue
@@ -1,0 +1,129 @@
+<template>
+  <div class="route-cards">
+    <div class="card" v-for='(route, key, i) in routes'>
+      <div class="card-header">
+        <div class="card-header-title">
+          /{{ key }}
+        </div>
+        <a class="card-header-icon" @click='toggle(i)'>
+          <span class="icon">
+            <i class="fa fa-angle-down"></i>
+          </span>
+        </a>
+      </div>
+      <div class="card-content" v-show='showCard[i]'>
+        <div class="content">
+          <table class='table is-narrow'>
+            <thead>
+              <tr>
+                <th>Route</th>
+                <th>Methods</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for='(child, childKey) in route.children'>
+                <td>
+                  <strong>{{ childKey }}</strong>
+                </td>
+                <td>
+                  <ul>
+                    <li v-if='childKey !== "/"'>
+                      <router-link active-class="is-active" :to="link(`${method} /${key}${childKey}`)" tag='span' class='tag' :class='classForMethod(method)' v-for='method in child' exact>
+                        {{ method }}
+                        <span class="mini tag is-dark" >{{ isCoreEndpoint(`${method} /${key}${childKey}`) }}</span>
+                      </router-link>
+                    </li>
+                    <li v-else>
+                      <router-link active-class="is-active" :to="link(`${method} /${key}`)" tag='span' class='tag' :class='classForMethod(method)' v-for='method in child' exact
+>
+                        {{ method }}
+                        <span class="mini tag is-dark" >{{ isCoreEndpoint(`${method} /${key}`) }}</span>
+                      </router-link>
+                    </li>
+                  </ul>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapGetters } from 'vuex'
+
+export default {
+  props: ['routes'],
+  data () {
+    return {
+      showCard: Object.keys(this.routes).map((e, i) => {
+        if (i === 0) return true
+        return false
+      })
+    }
+  },
+  computed: {
+    ...mapGetters(['isCoreEndpoint'])
+  },
+  methods: {
+    classForMethod (method) {
+      switch (method) {
+        case 'GET': return { 'is-success': true }
+        case 'POST': return { 'is-info': true }
+        case 'PUT': return { 'is-warning': true }
+        case 'DELETE': return { 'is-danger': true }
+        case 'PATCH': return { 'is-primary': true }
+        case 'OPTIONS': return { 'is-white': true }
+        default: return { 'is-black': true }
+      }
+    },
+    link (path) {
+      return {
+        name: this.$route.name === 'endpoint-reference' ? 'endpoint-reference' : 'endpoint',
+        params: {
+          path
+        }
+      }
+    },
+    toggle (i) {
+      this.showCard.splice(i, 1, !this.showCard[i])
+    }
+  }
+}
+</script>
+
+<style scoped>
+.content ul {
+  list-style-type: none;
+  cursor: pointer;
+  padding: 0;
+  margin: 0;
+}
+
+.content ul li {
+  display: inline-block;
+}
+
+.content ul li span {
+  min-width: 50px;
+  margin: 2px;
+}
+
+.route {
+  font-weight: bold;
+  min-width: 165px;
+  background: #eaeaea;
+  padding: .2px 5px;
+  border-radius: 2px;
+  margin: 0 5px;
+}
+
+.mini.tag {
+  min-width: auto;
+  border-radius: 2px;
+  height: auto;
+  padding: 0 5px;
+}
+</style>

--- a/src/components/RouteCard.vue
+++ b/src/components/RouteCard.vue
@@ -23,19 +23,31 @@
                   </div>
                   <ul>
                     <li v-if='childKey !== "/"'>
-                      <router-link active-class="is-active" :to="link(`${method} /${key}${childKey}`)" tag='span' class='tag' :class='classForMethod(method)' v-for='method in child' exact>
+                      <router-link active-class="is-active" :to="link(`${method} /${key}${childKey}`)" tag='span' class='tag tooltip-parent' :class='classForMethod(method)' v-for='method in child' exact>
                         {{ method }}&nbsp;
-                        <i v-if="isCoreEndpoint(`${method} /${key}${childKey}`) === 'core'" class="fa fa-dot-circle-o" title="This is an Apiko core endpoint."></i>
-                        <i v-if="isCoreEndpoint(`${method} /${key}${childKey}`) === 'overridden'" class="fa fa-wrench" title="This is an overriden core endpoint."></i>
-                        <i v-if="isCoreEndpoint(`${method} /${key}${childKey}`) === 'custom'" class="fa fa-puzzle-piece" title="This is a custom endpoint."></i>
+                        <i v-if="isCoreEndpoint(`${method} /${key}${childKey}`) === 'core'" class="fa fa-dot-circle-o ">
+                          <tooltip label="This is an Apiko core endpoint."/>
+                        </i>
+                        <i v-if="isCoreEndpoint(`${method} /${key}${childKey}`) === 'overridden'" class="fa fa-wrench">
+                          <tooltip label="This is an overriden core endpoint."/>
+                        </i>
+                        <i v-if="isCoreEndpoint(`${method} /${key}${childKey}`) === 'custom'" class="fa fa-puzzle-piece">
+                          <tooltip label="This is a custom endpoint."/>
+                        </i>
                       </router-link>
                     </li>
                     <li v-else>
-                      <router-link active-class="is-active" :to="link(`${method} /${key}`)" tag='span' class='tag' :class='classForMethod(method)' v-for='method in child' exact>
+                      <router-link active-class="is-active" :to="link(`${method} /${key}`)" tag='span' class='tag tooltip-parent' :class='classForMethod(method)' v-for='method in child' exact>
                         {{ method }}&nbsp;
-                        <i v-if="isCoreEndpoint(`${method} /${key}${childKey}`) === 'core'" class="fa fa-dot-circle-o" title="This is an Apiko core endpoint."></i>
-                        <i v-if="isCoreEndpoint(`${method} /${key}${childKey}`) === 'overridden'" class="fa fa-wrench" title="This is an overriden core endpoint."></i>
-                        <i v-if="isCoreEndpoint(`${method} /${key}${childKey}`) === 'custom'" class="fa fa-puzzle-piece" title="This is a custom endpoint."></i>
+                        <i v-if="isCoreEndpoint(`${method} /${key}`) === 'core'" class="fa fa-dot-circle-o">
+                          <tooltip label="This is an Apiko core endpoint."/>
+                        </i>
+                        <i v-if="isCoreEndpoint(`${method} /${key}`) === 'overridden'" class="fa fa-wrench">
+                          <tooltip label="This is an overriden core endpoint."/>
+                        </i>
+                        <i v-if="isCoreEndpoint(`${method} /${key}`) === 'custom'" class="fa fa-puzzle-piece">
+                          <tooltip label="This is a custom endpoint."/>
+                        </i>
                       </router-link>
                     </li>
                   </ul>
@@ -51,6 +63,7 @@
 
 <script>
 import { mapGetters } from 'vuex'
+import Tooltip from './Tooltip'
 
 export default {
   props: ['routes'],
@@ -88,6 +101,9 @@ export default {
     toggle (i) {
       this.showCard.splice(i, 1, !this.showCard[i])
     }
+  },
+  components: {
+    Tooltip
   }
 }
 </script>

--- a/src/components/Tooltip.vue
+++ b/src/components/Tooltip.vue
@@ -1,0 +1,55 @@
+<template>
+  <div class="tooltip-container">
+    <div class="tooltip-text">
+      {{ label }}
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  props: ['label', 'placement']
+}
+</script>
+
+<style>
+.tooltip-parent .tooltip-container {
+  display: none;
+}
+.tooltip-parent:hover .tooltip-container {
+  display: block;
+}
+
+.tooltip-parent {
+  position: relative;
+}
+</style>
+
+<style scoped>
+  .tooltip-container {
+    background: rgba(20, 20, 20, 0.9);
+    color: white;
+    position: absolute;
+    top:-2rem;
+    left: 50%;
+    transform: translateX(-50%);
+    border-radius: .2rem;
+  }
+  .tooltip-text {
+    font-family: Helvetica;
+    padding: 5px;
+    font-size: .9rem;
+    word-wrap: break-word;
+  }
+
+  .tooltip-container .tooltip-text::after {
+    content: "";
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    margin-left: -5px;
+    border-width: 5px;
+    border-style: solid;
+    border-color: #555 transparent transparent transparent;
+  }
+</style>

--- a/src/pages/Endpoints.vue
+++ b/src/pages/Endpoints.vue
@@ -9,14 +9,7 @@
           <div class="card-content">
             <div class="content">
 
-              <h1>Endpoints</h1>
-
-              <doc name="endpoints1"></doc>
-
-              <h3>Create an Endpoint</h3>
-              <endpoint-form @save="endpointCreated"></endpoint-form>
-
-              <doc name="endpoints2"></doc>
+              <router-view/>
 
             </div>
           </div>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -33,17 +33,23 @@ export default new VueRouter({
         },
         {
           path: '/endpoints',
-          component: require('../pages/Endpoints')
-        },
-        {
-          name: 'endpoint',
-          path: '/endpoints/:path',
-          component: require('../pages/Endpoint')
-        },
-        {
-          name: 'endpoint-reference',
-          path: '/endpoints/:path/reference',
-          component: require('../pages/Endpoint')
+          component: require('../pages/Endpoints'),
+          children: [
+            {
+              path: '/',
+              component: require('../components/EndpointFormView')
+            },
+            {
+              name: 'endpoint',
+              path: '/endpoints/:path',
+              component: require('../components/EndpointMethodView')
+            },
+            {
+              name: 'endpoint-reference',
+              path: '/endpoints/:path/reference',
+              component: require('../components/EndpointMethodView')
+            }
+          ]
         },
         {
           path: '/documentation',


### PR DESCRIPTION
Added tooltips

Fixed #22 by making the add new route page and endpoint configuration page as child routes, preventing re-initialization of the endpoints-list component.